### PR TITLE
XML prolog must come first in MF_TRACE.WPRP

### DIFF
--- a/performanceTracing/MF_TRACE.WPRP
+++ b/performanceTracing/MF_TRACE.WPRP
@@ -1,6 +1,6 @@
+<?xml version="1.0" encoding="utf-8" standalone='yes'?>
 <!-- Copyright (c) Microsoft Corporation. -->
 <!-- Licensed under the MIT License. -->
-<?xml version="1.0" encoding="utf-8" standalone='yes'?>
 
 <WindowsPerformanceRecorder Version="1.0" Author="Media Team" Team="Media Performance Team" Comments="Test" Company="Microsoft Corporation" Copyright="Microsoft Corporation" Tag="Media">
   <Profiles>


### PR DESCRIPTION
Copyright comments were causing a parsing error. Move them to come after the XML prolog.