### PR TITLE
Remove repeated InitializeVideo method call

### DIFF
--- a/samples/MediaEngineUWPSample/src/media/MediaEngineWrapper.cpp
+++ b/samples/MediaEngineUWPSample/src/media/MediaEngineWrapper.cpp
@@ -96,7 +96,6 @@ void MediaEngineWrapper::Initialize(IMFMediaSource* mediaSource)
 {
     RunSyncInMTA([&]()
     {
-        InitializeVideo();
         CreateMediaEngine(mediaSource);
     });
 }


### PR DESCRIPTION
 MediaEngineUWPSample (MediaEngineWrapper.cpp) was calling InitializeVideo twice, removed the first of the calls. 