### PR TITLE
Fixing casting issue in ConvertSecondsToHns() function.

### DIFF
--- a/samples/MediaEngineCustomSourceXamlSample/src/MediaFoundationHelpers.h
+++ b/samples/MediaEngineCustomSourceXamlSample/src/MediaFoundationHelpers.h
@@ -151,7 +151,7 @@ namespace media
     template<typename SecondsT>
     inline uint64_t ConvertSecondsToHns(SecondsT seconds)
     {
-        return static_cast<uint64_t>(seconds) * c_hnsPerSecond;
+        return static_cast<uint64_t>(seconds * c_hnsPerSecond);
     }
 
     template<typename HnsT>

--- a/samples/MediaEngineDCompWin32Sample/src/media/MediaFoundationHelpers.h
+++ b/samples/MediaEngineDCompWin32Sample/src/media/MediaFoundationHelpers.h
@@ -151,7 +151,7 @@ constexpr uint64_t c_hnsPerSecond = 10000000;
 template<typename SecondsT>
 inline uint64_t ConvertSecondsToHns(SecondsT seconds)
 {
-    return static_cast<uint64_t>(seconds) * c_hnsPerSecond;
+    return static_cast<uint64_t>(seconds * c_hnsPerSecond);
 }
 
 template<typename HnsT>

--- a/samples/MediaEngineEMEUWPSample/src/media/MediaFoundationHelpers.h
+++ b/samples/MediaEngineEMEUWPSample/src/media/MediaFoundationHelpers.h
@@ -151,7 +151,7 @@ constexpr uint64_t c_hnsPerSecond = 10000000;
 template<typename SecondsT>
 inline uint64_t ConvertSecondsToHns(SecondsT seconds)
 {
-    return static_cast<uint64_t>(seconds) * c_hnsPerSecond;
+    return static_cast<uint64_t>(seconds * c_hnsPerSecond);
 }
 
 template<typename HnsT>

--- a/samples/MediaEngineUWPSample/src/media/MediaFoundationHelpers.h
+++ b/samples/MediaEngineUWPSample/src/media/MediaFoundationHelpers.h
@@ -151,7 +151,7 @@ constexpr uint64_t c_hnsPerSecond = 10000000;
 template<typename SecondsT>
 inline uint64_t ConvertSecondsToHns(SecondsT seconds)
 {
-    return static_cast<uint64_t>(seconds) * c_hnsPerSecond;
+    return static_cast<uint64_t>(seconds * c_hnsPerSecond);
 }
 
 template<typename HnsT>


### PR DESCRIPTION
Fixing casting issue in ConvertSecondsToHns() function.  The problem was causing us to convert the floating point number of seconds into an integer and then convert it into HNS, resulting in a loss of precision.